### PR TITLE
fix for when download sa-rules failed

### DIFF
--- a/data/Dockerfiles/dovecot/sa-rules.sh
+++ b/data/Dockerfiles/dovecot/sa-rules.sh
@@ -21,5 +21,5 @@ if [[ -f /tmp/sa-rules.tar.gz ]]; then
       curl --silent --insecure -XPOST https://dockerapi/containers/${CONTAINER_ID}/restart
     fi
   fi
+  rm -r /tmp/sa-rules-heinlein /tmp/sa-rules.tar.gz
 fi
-rm -r /tmp/sa-rules-heinlein /tmp/sa-rules.tar.gz


### PR DESCRIPTION
When curl command failed due connection time out, rm command fail. Causing dovecot container restart.
So moved rm command into section when the file exists.